### PR TITLE
fix Terminal.Gui dependency

### DIFF
--- a/StuiPodcast.Core/StuiPodcast.Core.csproj
+++ b/StuiPodcast.Core/StuiPodcast.Core.csproj
@@ -6,8 +6,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Terminal.Gui" Version="1.19.0" />
-  </ItemGroup>
-
 </Project>

--- a/StuiPodcast.Core/StuiPodcast.Core.csproj
+++ b/StuiPodcast.Core/StuiPodcast.Core.csproj
@@ -7,9 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Terminal.Gui">
-      <HintPath>..\..\..\.nuget\packages\terminal.gui\1.19.0\lib\net8.0\Terminal.Gui.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Terminal.Gui" Version="1.19.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

I was trying to package this program with Nix, and found a problem with paths, which seems to be because there is a path being hard-coded. 

I'm going to be honest, I'm very unfamiliar with the C# ecosystem, and this was an LLM suggestion, but it seems reasonable to me and it fixed my build. But, if something breaks on your end or there is some reason why that is there, feel free to close the PR.

thanks for the nice software :)

## Type
- [x] fix
- [ ] feat
- [ ] docs
- [ ] build/ci
- [ ] refactor
- [ ] chore

## Checklist
- [ ] Tests or manual verification done
- [ ] For user-visible behavior: updated README/COMMANDS if needed


