### PR TITLE
add a way to delete a downloaded episode

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -123,9 +123,9 @@ Full in-app help: `:h`
   Jump selection to top, middle, or bottom of the current list.
 
 ### Downloads
-- `:download [start|cancel]` (alias `:dl`)  
-  Mark or unmark the episode for download, optionally start or cancel.  
-  Examples: `:download`, `:dl`, `:dl cancel`
+- `:download [start|cancel|rm]` (alias `:dl`)  
+  Queue the episode for download, or start, cancel or delete it. `rm` deletes the downloaded file and frees the space.  
+  Examples: `:download`, `:dl cancel`, `:dl rm`
 - `:downloads [retry-failed | clear-queue | open-dir]`  
   Show downloads overview and actions.  
   Examples: `:downloads`, `:downloads retry-failed`, `:downloads open-dir`

--- a/Podliner.App/Command/UseCases/DownloadUseCase.cs
+++ b/Podliner.App/Command/UseCases/DownloadUseCase.cs
@@ -143,6 +143,28 @@ internal sealed class DownloadUseCase
                 _ui.ShowOsd("Download canceled ✖");
                 break;
 
+            case "rm":
+            case "remove":
+            case "delete":
+            {
+                if (_dlm.GetState(ep.Id) != DownloadState.Done)
+                {
+                    _ui.ShowOsd("download: nothing to delete", 1500);
+                    break;
+                }
+
+                try
+                {
+                    var freed = _dlm.DeleteLocalFile(ep.Id);
+                    _ui.ShowOsd($"Download removed ({FormatBytes(freed)} freed)", 2000);
+                }
+                catch (Exception ex)
+                {
+                    _ui.ShowOsd($"download: delete failed ({ex.GetType().Name})", 2500);
+                }
+                break;
+            }
+
             default:
             {
                 var st = _dlm.GetState(ep.Id);
@@ -151,6 +173,13 @@ internal sealed class DownloadUseCase
                     _dlm.Enqueue(ep.Id);
                     _dlm.EnsureRunning();
                     _ui.ShowOsd("Download queued ⌵");
+                }
+                else if (st == DownloadState.Done)
+                {
+                    // Forget() drops the bookkeeping and leaves the file, so
+                    // this used to report "unqueued" and free nothing. Deleting
+                    // media is not something a bare :download should do.
+                    _ui.ShowOsd("already downloaded, :download rm deletes it", 2500);
                 }
                 else
                 {
@@ -164,6 +193,14 @@ internal sealed class DownloadUseCase
         _ = _persist();
         _ui.RefreshEpisodesForSelectedFeed(_episodes.Snapshot());
         return true;
+    }
+
+    static string FormatBytes(long bytes)
+    {
+        if (bytes >= 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024 * 1024):0.0} GB";
+        if (bytes >= 1024L * 1024)        return $"{bytes / (1024.0 * 1024):0.0} MB";
+        if (bytes >= 1024)                return $"{bytes / 1024.0:0.0} KB";
+        return $"{bytes} B";
     }
 
     public void DlToggle(string arg)

--- a/Podliner.App/HelpCatalog.cs
+++ b/Podliner.App/HelpCatalog.cs
@@ -204,10 +204,10 @@ namespace Podliner.App
                 Examples: new[]{ ":save", ":save on", ":save -" },
                 Category: HelpCategory.Downloads, Rank: 44),
 
-            new(":download", "Mark/unmark for download (auto-queued).",
-                "[start|cancel]",
+            new(":download", "Queue, cancel or delete the download of the selected episode.",
+                "[start|cancel|rm]",
                 Aliases: new[]{ ":dl" },
-                Examples: new[]{ ":download", ":download start", ":dl", ":dl cancel" },
+                Examples: new[]{ ":download", ":download start", ":dl cancel", ":dl rm" },
                 Category: HelpCategory.Downloads, Rank: 18),
 
             new(":downloads", "Downloads overview & actions.",

--- a/Podliner.Infra/Download/DownloadManager.cs
+++ b/Podliner.Infra/Download/DownloadManager.cs
@@ -105,6 +105,11 @@ namespace Podliner.Infra.Download
 
         private void SaveIndexDebounced() => _indexStore.SaveDebounced(CollectDoneItems);
 
+        // Writes the index straight away. Deleting a file has to survive a
+        // crash in the next 800ms, or the entry comes back on restart and
+        // points at a file that is gone.
+        public void SaveIndexNow() => _indexStore.SaveNow(CollectDoneItems);
+
         #endregion
 
         #region public control api
@@ -205,6 +210,42 @@ namespace Podliner.Infra.Download
                 Log.Information("dl/cancel id={Id} removedFromQueue={Removed} wasRunning={WasRunning}",
                     episodeId, pulsed, _running.ContainsKey(episodeId));
             }
+        }
+
+        // Deletes the downloaded file and drops the episode's download state.
+        // Returns the number of bytes freed; 0 when there was nothing on disk.
+        //
+        // Forget() alone only clears the bookkeeping, which is why ":download"
+        // on a finished download used to report success and free nothing.
+        public long DeleteLocalFile(Guid episodeId)
+        {
+            string? path;
+            lock (_gate)
+            {
+                path = _data.DownloadMap.TryGetValue(episodeId, out var st) ? st.LocalPath : null;
+            }
+
+            long freed = 0;
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                try
+                {
+                    var fi = new FileInfo(path);
+                    if (fi.Exists) { freed = fi.Length; fi.Delete(); }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "dl/delete failed id={Id} path={Path}", episodeId, path);
+                    throw;
+                }
+            }
+
+            Forget(episodeId);
+            SaveIndexNow();
+            try { StatusChanged?.Invoke(episodeId, new DownloadStatus { State = DownloadState.None }); } catch { }
+
+            Log.Information("dl/delete id={Id} freed={Freed} path={Path}", episodeId, freed, path);
+            return freed;
         }
 
         // Thread-safe "cancel + drop all state" for an episode. Replaces the

--- a/Podliner.Infra/Download/IDownloadManager.cs
+++ b/Podliner.Infra/Download/IDownloadManager.cs
@@ -1,4 +1,4 @@
-using Podliner.Core;
+﻿using Podliner.Core;
 
 namespace Podliner.Infra.Download;
 
@@ -23,6 +23,10 @@ public interface IDownloadManager : IDisposable
     void ForceFront(Guid episodeId);
     void Cancel(Guid episodeId);
     void Forget(Guid episodeId);
+
+    // Deletes the downloaded file and clears the episode's download state.
+    // Returns the bytes freed, 0 when there was nothing on disk.
+    long DeleteLocalFile(Guid episodeId);
     int ClearQueue();
 
     int QueuedCount();

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,8 @@
 - [X] `:queue add` was a second name for `toggle`, so running it on a queued episode dropped it back out. `add` now appends, `toggle` toggles, both say which way it went
 - [X] `:queue rm` was not undoable although `:undo` advertises reverting the last destructive action. It now restores the episode at the index it held
 - [X] The help browser and COMMANDS.md still named the default OPML export `stui-feeds.opml` after the rename, while the code writes `podliner-feeds.opml`. A test now fails if the old name reappears in any help text
+- [X] No way to delete a download. `:download` on a finished one called `Forget()`, which drops the bookkeeping and leaves the file, and reported "Download unqueued". Added `:download rm` (`IDownloadManager.DeleteLocalFile`) and made the bare command say what is actually true
+- [X] `JsonStoreContractTests.Debounced_SaveAsync_coalesces_bursts` slept a flat 300ms against a 100ms debounce and failed on every macOS and Windows CI runner. It polls for the timer now
 
 ### Dependencies
 - [X] Drop unused `Microsoft.Data.Sqlite` from Infra (removes the only high-severity advisory in the build)

--- a/tests/Podliner.App.Tests/Commands/CmdDownloadsModuleTests.cs
+++ b/tests/Podliner.App.Tests/Commands/CmdDownloadsModuleTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Podliner.App.Command.UseCases;
 using Podliner.App.Tests.Fakes;
 using Podliner.Core;
@@ -273,5 +273,84 @@ public sealed class CmdDownloadsModuleTests : IDisposable
     {
         _sut.Handle(":downloads set-dir relative-folder").Should().BeTrue();
         Path.IsPathRooted(_data.DownloadDir).Should().BeTrue();
+    }
+
+    // ── :download rm ─────────────────────────────────────────────────────────
+    //
+    // ":download" on a finished download reported "Download unqueued" and left
+    // the file on disk, and nothing else could delete it either. A podcast
+    // client has to be able to give the space back.
+
+    private Episode DownloadedEpisode(int bytes = 4096)
+    {
+        var ep = MakeEpisode();
+        var path = Path.Combine(_dir, ep.Id + ".mp3");
+        File.WriteAllBytes(path, new byte[bytes]);
+        _data.DownloadMap[ep.Id] = new DownloadStatus
+        {
+            State = DownloadState.Done,
+            LocalPath = path,
+            BytesReceived = bytes,
+            TotalBytes = bytes
+        };
+        return ep;
+    }
+
+    [Fact]
+    public void Download_rm_deletes_the_file_and_says_how_much_it_freed()
+    {
+        var ep = DownloadedEpisode(4096);
+        var path = _data.DownloadMap[ep.Id].LocalPath!;
+
+        _sut.Handle(":download rm").Should().BeTrue();
+
+        File.Exists(path).Should().BeFalse();
+        _data.DownloadMap.Should().NotContainKey(ep.Id);
+        _ui.OsdMessages.Last().Text.Should().Contain("freed");
+    }
+
+    [Fact]
+    public void Dl_rm_is_the_same_command()
+    {
+        var ep = DownloadedEpisode();
+        var path = _data.DownloadMap[ep.Id].LocalPath!;
+
+        _sut.Handle(":dl rm").Should().BeTrue();
+
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Download_rm_on_an_episode_that_is_not_downloaded_says_so()
+    {
+        MakeEpisode();
+
+        _sut.Handle(":download rm");
+
+        _ui.OsdMessages.Last().Text.Should().Be("download: nothing to delete");
+    }
+
+    [Fact]
+    public void A_bare_download_on_a_finished_one_does_not_claim_to_have_unqueued_it()
+    {
+        var ep = DownloadedEpisode();
+        var path = _data.DownloadMap[ep.Id].LocalPath!;
+
+        _sut.Handle(":download");
+
+        File.Exists(path).Should().BeTrue("a bare :download must never delete media");
+        _ui.OsdMessages.Last().Text.Should().Contain(":download rm",
+            "the message has to point at the command that actually removes it");
+    }
+
+    [Fact]
+    public void A_bare_download_still_unqueues_a_pending_one()
+    {
+        var ep = MakeEpisode(DownloadState.Queued);
+
+        _sut.Handle(":download");
+
+        _ui.OsdMessages.Last().Text.Should().Be("Download unqueued");
+        _data.DownloadMap.Should().NotContainKey(ep.Id);
     }
 }

--- a/tests/Podliner.App.Tests/Fakes/FakeDownloadManager.cs
+++ b/tests/Podliner.App.Tests/Fakes/FakeDownloadManager.cs
@@ -1,4 +1,4 @@
-using Podliner.Core;
+﻿using Podliner.Core;
 using Podliner.Infra.Download;
 
 namespace Podliner.App.Tests.Fakes;
@@ -54,6 +54,20 @@ sealed class FakeDownloadManager : IDownloadManager
         Forgotten.Add(episodeId);
         _queue.Remove(episodeId);
         _map.Remove(episodeId);
+    }
+
+    // Episodes whose file the caller asked to delete, and the bytes each
+    // delete should report back.
+    public List<Guid> Deleted { get; } = new();
+    public long BytesFreedPerDelete { get; set; } = 1024;
+
+    public long DeleteLocalFile(Guid episodeId)
+    {
+        var known = _map.ContainsKey(episodeId);
+        Deleted.Add(episodeId);
+        _queue.Remove(episodeId);
+        _map.Remove(episodeId);
+        return known ? BytesFreedPerDelete : 0;
     }
 
     public int ClearQueue()

--- a/tests/Podliner.Infra.Tests/Download/DownloadManagerDeleteTests.cs
+++ b/tests/Podliner.Infra.Tests/Download/DownloadManagerDeleteTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Podliner.Core;
+using Podliner.Infra.Download;
+using Podliner.Infra.Storage;
+using Xunit;
+
+namespace Podliner.Infra.Tests.Download;
+
+// A podcast client that can download but never delete fills the disk and
+// leaves the user no way out. ":download" on a finished download used to call
+// Forget(), which drops the map entry and says "Download unqueued" while the
+// file stays exactly where it was.
+public sealed class DownloadManagerDeleteTests : IDisposable
+{
+    private readonly string _dir;
+
+    public DownloadManagerDeleteTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "podliner-dldel-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private (DownloadManager mgr, AppData data, LibraryStore lib, Guid id, string path) Downloaded(int bytes = 2048)
+    {
+        var data = new AppData();
+        var lib = new LibraryStore(_dir); lib.Load();
+        var mgr = new DownloadManager(data, lib, _dir);
+
+        var id = Guid.NewGuid();
+        var path = Path.Combine(_dir, "episode.mp3");
+        File.WriteAllBytes(path, new byte[bytes]);
+
+        data.DownloadMap[id] = new DownloadStatus
+        {
+            State = DownloadState.Done,
+            LocalPath = path,
+            BytesReceived = bytes,
+            TotalBytes = bytes
+        };
+
+        return (mgr, data, lib, id, path);
+    }
+
+    [Fact]
+    public void Deleting_a_finished_download_removes_the_file()
+    {
+        var (mgr, data, lib, id, path) = Downloaded(2048);
+        using (mgr) using (lib)
+        {
+            var freed = mgr.DeleteLocalFile(id);
+
+            freed.Should().Be(2048);
+            File.Exists(path).Should().BeFalse();
+            data.DownloadMap.Should().NotContainKey(id, "the episode is no longer downloaded");
+        }
+    }
+
+    [Fact]
+    public void Deleting_reports_zero_when_there_is_nothing_to_delete()
+    {
+        var data = new AppData();
+        using var lib = new LibraryStore(_dir); lib.Load();
+        using var mgr = new DownloadManager(data, lib, _dir);
+
+        mgr.DeleteLocalFile(Guid.NewGuid()).Should().Be(0);
+    }
+
+    [Fact]
+    public void Deleting_an_entry_whose_file_is_already_gone_still_clears_the_state()
+    {
+        var (mgr, data, lib, id, path) = Downloaded();
+        using (mgr) using (lib)
+        {
+            File.Delete(path);
+
+            mgr.DeleteLocalFile(id).Should().Be(0, "no bytes were freed, the file was gone");
+            data.DownloadMap.Should().NotContainKey(id, "a stale entry has to go too");
+        }
+    }
+
+    [Fact]
+    public void A_deleted_download_does_not_come_back_from_the_index()
+    {
+        var (mgr, data, lib, id, path) = Downloaded();
+        using (mgr) using (lib)
+        {
+            mgr.DeleteLocalFile(id);
+            mgr.SaveIndexNow();
+        }
+
+        var data2 = new AppData();
+        using var lib2 = new LibraryStore(_dir); lib2.Load();
+        using var mgr2 = new DownloadManager(data2, lib2, _dir);
+
+        data2.DownloadMap.Should().NotContainKey(id);
+    }
+
+    [Fact]
+    public void The_state_reported_after_a_delete_is_None()
+    {
+        var (mgr, data, lib, id, _) = Downloaded();
+        using (mgr) using (lib)
+        {
+            mgr.DeleteLocalFile(id);
+
+            mgr.GetState(id).Should().Be(DownloadState.None);
+        }
+    }
+}


### PR DESCRIPTION
found while clicking through the tui: there is no way to get rid of a download.

`:download` on a finished download calls `Forget()`, which only drops the bookkeeping. it prints "Download unqueued", the file stays on disk and the episode still shows the downloaded badge. nothing else can delete it either, so the only way to free space was to go into the folder by hand.

adds `IDownloadManager.DeleteLocalFile`, which deletes the file, clears the map entry and writes the index straight away so the entry does not come back on the next start. exposed as `:download rm` (also `:dl rm`). a bare `:download` on a finished one now says "already downloaded, :download rm deletes it" instead of claiming it unqueued something, because deleting media on an accidental keypress would be nasty.

10 new tests, 5 on the manager and 5 on the command. checked live: 117 mb file deleted, index back to 19 entries after a restart, badge gone.