### PR TITLE
rebuild the store caches when the library changes underneath

### DIFF
--- a/Podliner.App/Services/EpisodeStore.cs
+++ b/Podliner.App/Services/EpisodeStore.cs
@@ -1,4 +1,4 @@
-using Podliner.Core;
+﻿using Podliner.Core;
 using Podliner.Infra.Storage;
 
 namespace Podliner.App.Services;
@@ -13,6 +13,11 @@ internal sealed class EpisodeStore : IEpisodeStore
     readonly LibraryStore _lib;
     readonly object _gate = new();
     IReadOnlyList<Episode>? _snapshot;
+
+    // LibraryStore.Revision at the time _snapshot was built. A feed refresh
+    // adds every new episode through FeedService, which writes into the
+    // library directly, so our own mutations are not the only ones.
+    int _cachedRevision = -1;
 
     public event Action<EpisodeChange>? Changed;
 
@@ -30,6 +35,8 @@ internal sealed class EpisodeStore : IEpisodeStore
     {
         lock (_gate)
         {
+            var rev = _lib.Revision;
+            if (rev != _cachedRevision) { _cachedRevision = rev; _snapshot = null; }
             return _snapshot ??= _lib.Current.Episodes.ToArray();
         }
     }
@@ -75,6 +82,7 @@ internal sealed class EpisodeStore : IEpisodeStore
             wasNew = !_lib.TryGetEpisode(ep.Id, out _);
             persisted = _lib.AddOrUpdateEpisode(ep);
             _snapshot = null;
+            _cachedRevision = _lib.Revision;
         }
 
         Fire(wasNew ? EpisodeChangeKind.Added : EpisodeChangeKind.Updated, persisted);
@@ -89,6 +97,7 @@ internal sealed class EpisodeStore : IEpisodeStore
             if (!_lib.TryGetEpisode(id, out gone) || gone == null) return false;
             _lib.RemoveEpisode(id);
             _snapshot = null;
+            _cachedRevision = _lib.Revision;
         }
 
         Fire(EpisodeChangeKind.Removed, gone);
@@ -104,6 +113,7 @@ internal sealed class EpisodeStore : IEpisodeStore
             if (removed.Count == 0) return 0;
             _lib.RemoveEpisodesByFeed(feedId);
             _snapshot = null;
+            _cachedRevision = _lib.Revision;
         }
 
         foreach (var ep in removed) Fire(EpisodeChangeKind.Removed, ep);

--- a/Podliner.App/Services/FeedStore.cs
+++ b/Podliner.App/Services/FeedStore.cs
@@ -1,4 +1,4 @@
-using Podliner.Core;
+﻿using Podliner.Core;
 using Podliner.Infra.Storage;
 
 namespace Podliner.App.Services;
@@ -14,6 +14,12 @@ internal sealed class FeedStore : IFeedStore
     IReadOnlyList<Feed>? _snapshot;
     Dictionary<string, Feed>? _byUrl;
 
+    // LibraryStore.Revision at the time the cache above was built. FeedService
+    // writes into the library directly, so our own mutations are not the only
+    // ones and dropping the cache on those alone left ":add" painting a list
+    // from before the feed existed.
+    int _cachedRevision = -1;
+
     public event Action<FeedChange>? Changed;
 
     public FeedStore(LibraryStore lib)
@@ -28,7 +34,20 @@ internal sealed class FeedStore : IFeedStore
 
     public IReadOnlyList<Feed> Snapshot()
     {
-        lock (_gate) return _snapshot ??= _lib.Current.Feeds.ToArray();
+        lock (_gate)
+        {
+            DropCacheIfLibraryMoved_Locked();
+            return _snapshot ??= _lib.Current.Feeds.ToArray();
+        }
+    }
+
+    void DropCacheIfLibraryMoved_Locked()
+    {
+        var rev = _lib.Revision;
+        if (rev == _cachedRevision) return;
+        _cachedRevision = rev;
+        _snapshot = null;
+        _byUrl = null;
     }
 
     public bool TryGet(Guid id, out Feed? feed)
@@ -55,6 +74,7 @@ internal sealed class FeedStore : IFeedStore
         if (string.IsNullOrWhiteSpace(url)) return null;
         lock (_gate)
         {
+            DropCacheIfLibraryMoved_Locked();
             EnsureUrlIndex_Locked();
             return _byUrl!.TryGetValue(url, out var f) ? f : null;
         }
@@ -74,6 +94,7 @@ internal sealed class FeedStore : IFeedStore
             persisted = _lib.AddOrUpdateFeed(feed);
             _snapshot = null;
             _byUrl = null; // invalidate URL index
+            _cachedRevision = _lib.Revision;
         }
 
         Fire(wasNew ? FeedChangeKind.Added : FeedChangeKind.Updated, persisted);
@@ -90,6 +111,7 @@ internal sealed class FeedStore : IFeedStore
             _lib.RemoveFeed(id);
             _snapshot = null;
             _byUrl = null;
+            _cachedRevision = _lib.Revision;
         }
 
         Fire(FeedChangeKind.Removed, gone);

--- a/Podliner.Infra/Storage/LibraryStore.cs
+++ b/Podliner.Infra/Storage/LibraryStore.cs
@@ -1,4 +1,4 @@
-using Podliner.Core;
+﻿using Podliner.Core;
 
 namespace Podliner.Infra.Storage
 {
@@ -270,6 +270,19 @@ namespace Podliner.Infra.Storage
         }
 
         // ── feed upsert ─────────────────────────────────────────────────────
+        // Bumped whenever the feed or episode collections change shape.
+        //
+        // FeedService lives in Infra and writes through AppFacade straight into
+        // this store, which the App-side FeedStore and EpisodeStore caches
+        // cannot observe. They compare this counter instead of trusting their
+        // own mutations to be the only ones. Field edits (progress, saved,
+        // queue, history) deliberately do not bump it: the caches hold the
+        // same Episode references, and progress alone fires four times a
+        // second during playback.
+        public int Revision => System.Threading.Volatile.Read(ref _revision);
+        int _revision;
+        void BumpRevision() => System.Threading.Interlocked.Increment(ref _revision);
+
         public Feed AddOrUpdateFeed(Feed feed)
         {
             if (feed == null) throw new ArgumentNullException(nameof(feed));
@@ -289,6 +302,7 @@ namespace Podliner.Infra.Storage
                 {
                     if (!string.IsNullOrWhiteSpace(feed.Title)) dup.Title = feed.Title;
                     if (feed.LastChecked.HasValue)              dup.LastChecked = feed.LastChecked;
+                    BumpRevision();
                     SaveAsync();
                     return dup;
                 }
@@ -308,6 +322,7 @@ namespace Podliner.Infra.Storage
                 _feedsById[feed.Id] = feed;
             }
 
+            BumpRevision();
             SaveAsync();
             return _feedsById[feed.Id];
         }
@@ -341,6 +356,7 @@ namespace Podliner.Infra.Storage
                 _episodesById[ep.Id] = ep;
             }
 
+            BumpRevision();
             SaveAsync();
             return _episodesById[ep.Id];
         }
@@ -484,6 +500,7 @@ namespace Podliner.Infra.Storage
             // immediate notification that the in-memory state changed.
             // The subsequent debounced save will run Changed a second time;
             // subscribers that care must be idempotent.
+            BumpRevision();
             SaveAsync();
         }
     }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,7 +90,8 @@
 - [X] Refresh/Redraw ui on mac/linux after moving window (issue #4). Terminal.Gui detects resizes by polling, not by SIGWINCH: `CursesDriver.ProcessWinChange` → `Curses.CheckWinChange` compares ncurses' `LINES`/`COLS` globals against a cached copy, and only runs from `CursesDriver.Refresh` and the input loop. A missed poll leaves every Toplevel at the old frame. Fixed with `UiShell.ForceRedraw` (public Terminal.Gui API only), wired to `:redraw`, Ctrl+L, and a self-heal check in the 250ms UI tick.
 
 ### Packaging
-- [ ] Add the nixpkgs entry to README and the bug-report template once the package lands
+- [ ] Nix packaging has no owner. odilf packaged podliner for his own dotfiles while fixing the Terminal.Gui HintPath (PR #27) but will not submit it to nixpkgs, so nothing is landing. Either someone picks it up or the README and the bug-report template keep no nix entry.
+      Whoever does it needs a wrapper setting `LD_LIBRARY_PATH` and `LIBVLC_PLUGIN_PATH`, because LibVLCSharp dlopens libvlc at runtime and engine detection otherwise falls back to mpv or ffplay without saying so.
 
 ## Done
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,7 @@
 - [X] Clear the remaining compiler warnings in the test projects
 - [ ] Fix playerui update (windows only?)
 - [X] Player control row overlaps itself below ~140 columns (now drops controls by tier: download, then skips + volume bar, then ±spd)
+- [X] `:add <url>` fetched, persisted and logged the feed and then left the sidebar empty until the next start. `FeedService` lives in Infra and writes through `AppFacade` into `LibraryStore`, which the App-side `FeedStore`/`EpisodeStore` snapshot caches cannot observe, so they kept handing out a list from before the feed existed. `LibraryStore.Revision` now stamps every structural change and both caches compare against it. Same root cause for episodes pulled by `:refresh`
 - [X] Help browser: the `Search:` label sat at the same X/Y as the search field and was overdrawn, so both tabs showed a blank first row
 - [X] `:theme` with no argument toggled the theme and then wiped `ThemePref`, losing the choice on the next start; unknown names silently applied MenuAccent
 - [X] F12 logs overlay showed a single line above 27 blank rows: `TextView.MoveEnd` parks the view on the last line even when the log fits

--- a/tests/Podliner.App.Tests/Services/StoreCacheInvalidationTests.cs
+++ b/tests/Podliner.App.Tests/Services/StoreCacheInvalidationTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Podliner.App.Services;
+using Podliner.Core;
+using Podliner.Infra.Storage;
+using Xunit;
+
+namespace Podliner.App.Tests.Services;
+
+// FeedStore and EpisodeStore cache a snapshot of LibraryStore.Current and drop
+// it on their own mutations. But FeedService lives in Infra and writes through
+// AppFacade straight into LibraryStore, which the App-side stores cannot see.
+//
+// That is the whole ":add <url>" bug: the feed is fetched, persisted and
+// logged as added, then the sidebar paints a cached list that predates it and
+// stays empty until the next start.
+public sealed class StoreCacheInvalidationTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly LibraryStore _lib;
+
+    public StoreCacheInvalidationTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "podliner-storecache-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _lib = new LibraryStore(_dir);
+        _lib.Load();
+    }
+
+    public void Dispose()
+    {
+        try { _lib.Dispose(); } catch { }
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void A_feed_added_straight_to_the_library_shows_up_in_the_store()
+    {
+        var store = new FeedStore(_lib);
+        store.Snapshot().Should().BeEmpty();
+
+        // What FeedService.AddFeedAsync does, via AppFacade.
+        _lib.AddOrUpdateFeed(new Feed { Title = "Darknet Diaries", Url = "https://example.test/rss" });
+
+        store.Snapshot().Should().ContainSingle().Which.Title.Should().Be("Darknet Diaries");
+    }
+
+    [Fact]
+    public void Episodes_added_by_a_refresh_show_up_in_the_store()
+    {
+        var store = new EpisodeStore(_lib);
+        // Episodes need a feed to hang off, same as after a real ":add".
+        var feedId = _lib.AddOrUpdateFeed(new Feed { Title = "F", Url = "https://example.test/f" }).Id;
+        store.Snapshot().Should().BeEmpty();
+
+        // What FeedService.RefreshFeedAsync does for every new item.
+        for (int i = 0; i < 3; i++)
+            _lib.AddOrUpdateEpisode(new Episode
+            {
+                Id = Guid.NewGuid(), FeedId = feedId,
+                Title = $"ep-{i}", AudioUrl = $"https://example.test/{i}.mp3"
+            });
+
+        store.Snapshot().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void A_feed_removed_straight_from_the_library_disappears_from_the_store()
+    {
+        var store = new FeedStore(_lib);
+        var feed = _lib.AddOrUpdateFeed(new Feed { Title = "Gone", Url = "https://example.test/gone" });
+        store.Snapshot().Should().ContainSingle();
+
+        _lib.RemoveFeed(feed.Id);
+
+        store.Snapshot().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void The_url_index_notices_a_feed_added_behind_the_stores_back()
+    {
+        var store = new FeedStore(_lib);
+        store.ContainsUrl("https://example.test/rss").Should().BeFalse();
+
+        _lib.AddOrUpdateFeed(new Feed { Title = "Later", Url = "https://example.test/rss" });
+
+        store.ContainsUrl("https://example.test/rss").Should().BeTrue(
+            "otherwise ':add' on an existing feed stops reporting 'already added'");
+    }
+
+    [Fact]
+    public void Repeated_snapshots_with_no_mutation_hand_back_the_same_instance()
+    {
+        var store = new FeedStore(_lib);
+        _lib.AddOrUpdateFeed(new Feed { Title = "Stable", Url = "https://example.test/s" });
+
+        var first = store.Snapshot();
+        var second = store.Snapshot();
+
+        second.Should().BeSameAs(first, "the cache is there to keep the hot render path off a full copy");
+    }
+}


### PR DESCRIPTION
adding your first feed does nothing visible. `:add <url>` fetches it, persists it and logs `ui/addfeed ok`, and the sidebar stays empty until you restart the app. same for episodes pulled by `:refresh`.

reason: `FeedService` is in Infra and writes through `AppFacade` straight into `LibraryStore`. the App-side `FeedStore` and `EpisodeStore` cache a snapshot and only drop it on their own mutations, which they never see here, so they keep handing out a list from before the feed existed.

`LibraryStore.Revision` now counts structural changes to the feed and episode collections and both caches compare against it. field edits (progress, saved, queue, history) deliberately do not bump it, since progress alone fires four times a second during playback and the caches hold the same episode references anyway.

5 new tests. checked live against an empty library: first feed shows up straight away, second one too, `:remove-feed` disappears immediately.