### PR TITLE
render multi-line osd messages and make copy work on wayland

### DIFF
--- a/Podliner.App/Command/UseCases/IoUseCase.cs
+++ b/Podliner.App/Command/UseCases/IoUseCase.cs
@@ -1,4 +1,4 @@
-using Podliner.App.Services;
+﻿using Podliner.App.Services;
 using Podliner.App.UI;
 
 namespace Podliner.App.Command.UseCases;
@@ -92,41 +92,59 @@ internal sealed class IoUseCase
         return null;
     }
 
+    // Runs the platform's clipboard tools in order until one of them takes
+    // the text. A tool that is not installed throws on Start and we move on;
+    // one that exits non-zero has failed and we move on too.
+    //
+    // The old version tried xclip and xsel and returned true unconditionally,
+    // so on Wayland ":copy" reported "copied" while the clipboard kept its
+    // previous contents: xclip exits 0 there without owning the selection.
     static bool TryCopyToClipboard(string text)
     {
-        try
+        var candidates = Services.ClipboardCommand.Candidates(
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS(),
+            Services.ClipboardCommand.HasWaylandSession(),
+            text);
+
+        foreach (var c in candidates)
         {
-            if (OperatingSystem.IsWindows())
+            try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo("powershell", $"-NoProfile -Command Set-Clipboard -Value @'\n{text}\n'@")
-                { UseShellExecute = false, RedirectStandardError = true, RedirectStandardOutput = true };
+                var psi = new System.Diagnostics.ProcessStartInfo(c.File, c.Arguments)
+                {
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardInput = Services.ClipboardCommand.WritesToStdin(c)
+                };
+
                 using var p = System.Diagnostics.Process.Start(psi);
-                p?.WaitForExit(1200);
-                return p != null && p.ExitCode == 0;
-            }
-            if (OperatingSystem.IsMacOS())
-            {
-                var psi = new System.Diagnostics.ProcessStartInfo("pbcopy") { UseShellExecute = false, RedirectStandardInput = true };
-                using var p = System.Diagnostics.Process.Start(psi);
-                p!.StandardInput.Write(text); p.StandardInput.Close(); p.WaitForExit(800);
+                if (p == null) continue;
+
+                if (Services.ClipboardCommand.WritesToStdin(c))
+                {
+                    p.StandardInput.Write(text);
+                    p.StandardInput.Close();
+                }
+
+                // xclip and wl-copy fork and keep running to serve the
+                // selection, which is a success, not a hang. Only an exit
+                // inside the window with a non-zero code means it failed.
+                if (p.WaitForExit(1200) && p.ExitCode != 0)
+                {
+                    Serilog.Log.Debug("copy: {Tool} exited {Code}", c.File, p.ExitCode);
+                    continue;
+                }
+
                 return true;
             }
-            foreach (var tool in new[] { "xclip", "xsel" })
+            catch (Exception ex)
             {
-                try
-                {
-                    var psi = tool == "xclip"
-                        ? new System.Diagnostics.ProcessStartInfo("xclip", "-selection clipboard")
-                        : new System.Diagnostics.ProcessStartInfo("xsel", "--clipboard --input");
-                    psi.UseShellExecute = false; psi.RedirectStandardInput = true;
-                    using var p = System.Diagnostics.Process.Start(psi);
-                    p!.StandardInput.Write(text); p.StandardInput.Close(); p.WaitForExit(800);
-                    return true;
-                }
-                catch { }
+                Serilog.Log.Debug(ex, "copy: {Tool} unavailable", c.File);
             }
         }
-        catch { }
+
         return false;
     }
 }

--- a/Podliner.App/Services/ClipboardCommand.cs
+++ b/Podliner.App/Services/ClipboardCommand.cs
@@ -1,0 +1,37 @@
+namespace Podliner.App.Services;
+
+// Which external tool gets the text, in which order.
+//
+// The Linux list used to be xclip then xsel. On a Wayland session xclip talks
+// to an X server that is not serving the clipboard, exits 0, and changes
+// nothing, so ":copy" reported success while the clipboard kept its old
+// contents. wl-copy is the tool that works there.
+internal static class ClipboardCommand
+{
+    internal readonly record struct Candidate(string File, string Arguments);
+
+    public static IReadOnlyList<Candidate> Candidates(bool isWindows, bool isMac, bool hasWayland, string text)
+    {
+        if (isWindows)
+            return new[] { new Candidate("powershell", $"-NoProfile -Command Set-Clipboard -Value @'\n{text}\n'@") };
+
+        if (isMac)
+            return new[] { new Candidate("pbcopy", "") };
+
+        var xclip = new Candidate("xclip", "-selection clipboard");
+        var xsel  = new Candidate("xsel", "--clipboard --input");
+        var wl    = new Candidate("wl-copy", "");
+
+        // Both can be installed side by side; the session decides which one
+        // actually owns the clipboard.
+        return hasWayland
+            ? new[] { wl, xclip, xsel }
+            : new[] { xclip, xsel, wl };
+    }
+
+    public static bool HasWaylandSession()
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
+
+    // Windows takes the text as a command-line argument; the others read stdin.
+    public static bool WritesToStdin(in Candidate c) => c.File != "powershell";
+}

--- a/Podliner.App/UI/UiOsdOverlay.cs
+++ b/Podliner.App/UI/UiOsdOverlay.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Terminal.Gui;
 
 namespace Podliner.App.UI;
@@ -70,24 +70,32 @@ internal sealed class UiOsdOverlay
 
         var driverCols = Application.Driver?.Cols ?? 80;
         var maxWidth = Math.Max(MinWidth, driverCols - 4); // 2 cols margin each side
-        var desired = Math.Clamp(text.Length + Padding, MinWidth, maxWidth);
 
-        // clip to one line (no wrapping)
-        var clippedText = text;
-        if (text.Length + Padding > maxWidth && maxWidth >= Padding)
+        // Callers may pass more than one line (":engine show" sends three).
+        // Each line is clipped on its own; sizing off the raw string counted
+        // the newlines and every line's length together, which made the box
+        // wider than the screen and still painted only one line of it.
+        var lines = text.Replace("\r\n", "\n").Split('\n');
+        var roomForText = Math.Max(0, maxWidth - Padding - 1); // leave space for ellipsis
+
+        for (int i = 0; i < lines.Length; i++)
         {
-            var roomForText = Math.Max(0, maxWidth - Padding - 1); // leave space for ellipsis
-            clippedText = roomForText > 0 && text.Length > roomForText
-                ? text.Substring(0, roomForText) + "…"
-                : text;
-            desired = Math.Clamp(clippedText.Length + Padding, MinWidth, maxWidth);
+            var line = lines[i];
+            if (line.Length + Padding > maxWidth && maxWidth >= Padding && roomForText > 0 && line.Length > roomForText)
+                lines[i] = line.Substring(0, roomForText) + "…";
         }
+
+        var widest = 0;
+        foreach (var line in lines) widest = Math.Max(widest, line.Length);
+        var desired = Math.Clamp(widest + Padding, MinWidth, maxWidth);
+
+        var clippedText = string.Join("\n", lines);
 
         _lastText = clippedText;
         _label!.Text = _lastText;
 
         _win!.Width = Dim.Sized(desired);
-        _win.Height = Dim.Sized(3);
+        _win.Height = Dim.Sized(lines.Length + 2); // one row per line plus the borders
         _win.X = Pos.Center();
         _win.Y = Pos.At(1); // slightly below top edge
         _win.Visible = true;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,8 @@
 - [ ] Fix playerui update (windows only?)
 - [X] Player control row overlaps itself below ~140 columns (now drops controls by tier: download, then skips + volume bar, then ±spd)
 - [X] `:add <url>` fetched, persisted and logged the feed and then left the sidebar empty until the next start. `FeedService` lives in Infra and writes through `AppFacade` into `LibraryStore`, which the App-side `FeedStore`/`EpisodeStore` snapshot caches cannot observe, so they kept handing out a list from before the feed existed. `LibraryStore.Revision` now stamps every structural change and both caches compare against it. Same root cause for episodes pulled by `:refresh`
+- [X] `:engine show` printed one of its three lines. `UiOsdOverlay` was pinned to `Height 3` and sized its width off the raw string, newlines included, so the box ran past the screen edge and painted only the middle line
+- [X] `:copy` reported "copied" and left the clipboard untouched on Wayland. The Linux path only tried xclip and xsel, and xclip exits 0 on a Wayland session without owning the selection; the result was never checked either. `wl-copy` is tried first there now and a non-zero exit falls through to the next tool
 - [X] Help browser: the `Search:` label sat at the same X/Y as the search field and was overdrawn, so both tabs showed a blank first row
 - [X] `:theme` with no argument toggled the theme and then wiped `ThemePref`, losing the choice on the next start; unknown names silently applied MenuAccent
 - [X] F12 logs overlay showed a single line above 27 blank rows: `TextView.MoveEnd` parks the view on the last line even when the log fits

--- a/tests/Podliner.App.Tests/Services/ClipboardCommandTests.cs
+++ b/tests/Podliner.App.Tests/Services/ClipboardCommandTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Podliner.App.Services;
+using Xunit;
+
+namespace Podliner.App.Tests.Services;
+
+// ":copy" said "copied" and left the clipboard untouched on Wayland: the only
+// Linux candidates were xclip and xsel, and xclip exits 0 on a Wayland session
+// without owning the clipboard, so nothing ever reported a failure.
+public sealed class ClipboardCommandTests
+{
+    private static IReadOnlyList<string> Tools(bool win = false, bool mac = false, bool wayland = false)
+        => ClipboardCommand.Candidates(win, mac, wayland, "hello").Select(c => c.File).ToList();
+
+    [Fact]
+    public void A_wayland_session_reaches_for_wl_copy_first()
+    {
+        Tools(wayland: true).Should().StartWith(new[] { "wl-copy" });
+    }
+
+    [Fact]
+    public void An_x_session_reaches_for_xclip_first()
+    {
+        Tools(wayland: false).Should().StartWith(new[] { "xclip" });
+    }
+
+    [Fact]
+    public void Every_linux_tool_stays_available_as_a_fallback()
+    {
+        Tools(wayland: true).Should().BeEquivalentTo(new[] { "wl-copy", "xclip", "xsel" });
+        Tools(wayland: false).Should().BeEquivalentTo(new[] { "wl-copy", "xclip", "xsel" });
+    }
+
+    [Fact]
+    public void Windows_and_mac_have_exactly_one_tool_each()
+    {
+        Tools(win: true).Should().Equal("powershell");
+        Tools(mac: true).Should().Equal("pbcopy");
+    }
+
+    [Fact]
+    public void Only_powershell_takes_the_text_as_an_argument()
+    {
+        var win = ClipboardCommand.Candidates(true, false, false, "hello").Single();
+        win.Arguments.Should().Contain("hello");
+        ClipboardCommand.WritesToStdin(win).Should().BeFalse();
+
+        foreach (var c in ClipboardCommand.Candidates(false, false, true, "hello"))
+        {
+            c.Arguments.Should().NotContain("hello");
+            ClipboardCommand.WritesToStdin(c).Should().BeTrue();
+        }
+    }
+}

--- a/tests/Podliner.App.Tests/Services/SaveSchedulerTests.cs
+++ b/tests/Podliner.App.Tests/Services/SaveSchedulerTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Podliner.App.Services;
 using Podliner.Core;
 using Podliner.Infra.Storage;
@@ -33,7 +33,8 @@ public sealed class SaveSchedulerTests : IDisposable
         try { Directory.Delete(_dir, recursive: true); } catch { }
     }
 
-    private SaveScheduler Create() => new(_data, _facade, () => _syncCount++);
+    // The scheduler bumps this from its debounce timer thread.
+    private SaveScheduler Create() => new(_data, _facade, () => Interlocked.Increment(ref _syncCount));
 
     [Fact]
     public async Task Flush_saves_immediately()
@@ -65,11 +66,16 @@ public sealed class SaveSchedulerTests : IDisposable
         await sched.RequestSaveAsync();
         await sched.RequestSaveAsync();
 
-        // Wait for debounce timer (MIN_INTERVAL_MS = 1000)
-        await Task.Delay(1500);
+        // Wait for the debounce timer (MIN_INTERVAL_MS = 1000) to fire rather
+        // than sleeping a fixed span past it. A flat 1500ms passed here and on
+        // ubuntu and failed on the slower macOS runner, where the timer had
+        // simply not run yet.
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline && Volatile.Read(ref _syncCount) < 2)
+            await Task.Delay(25);
 
         // Should have debounced: 1 immediate + 1 delayed = at least 2
-        _syncCount.Should().BeGreaterOrEqualTo(2);
+        Volatile.Read(ref _syncCount).Should().BeGreaterOrEqualTo(2);
     }
 
     [Fact]

--- a/tests/Podliner.App.Tests/UI/UiOsdOverlayTests.cs
+++ b/tests/Podliner.App.Tests/UI/UiOsdOverlayTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Podliner.App.Debug;
 using Podliner.App.UI;
 using Terminal.Gui;
@@ -143,5 +143,58 @@ public sealed class UiOsdOverlayTests
         ShowAndPump(shell, tui, "💤 sleep timer: playback stopped");
 
         tui.ScreenContains("sleep timer").Should().BeTrue();
+    }
+
+    // ── multi-line messages ─────────────────────────────────────────────────
+    //
+    // ":engine show" builds three lines: the active engine, the preference and
+    // the capability list. The overlay was pinned to Height 3 and sized its
+    // width from the raw string length, so it painted one line of the three
+    // and made itself as wide as all of them put together.
+
+    [Fact]
+    public void Every_line_of_a_multi_line_message_reaches_the_screen()
+    {
+        using var tui = new TuiHarness(120, 30);
+        var shell = BuildShell();
+        tui.Render();
+
+        ShowAndPump(shell, tui, "engine active: mpv\npreference: auto\nsupports: seek speed volume");
+
+        tui.ScreenContains("engine active: mpv").Should().BeTrue(tui.Screen());
+        tui.ScreenContains("preference: auto").Should().BeTrue(tui.Screen());
+        tui.ScreenContains("supports: seek speed volume").Should().BeTrue(tui.Screen());
+    }
+
+    [Fact]
+    public void A_multi_line_box_is_only_as_wide_as_its_longest_line()
+    {
+        using var tui = new TuiHarness(120, 30);
+        var shell = BuildShell();
+        tui.Render();
+
+        ShowAndPump(shell, tui, "short\na much longer second line\nmid");
+
+        var row = tui.RowOf("a much longer second line");
+        row.Should().BeGreaterThan(-1);
+
+        // The box borders sit on the rows above and below the text block.
+        var top = tui.Line(row - 2);
+        top.Trim().Length.Should().BeLessThan(40,
+            "the width used to come from the whole string, newlines included");
+    }
+
+    [Fact]
+    public void A_single_line_message_still_gets_a_three_row_box()
+    {
+        using var tui = new TuiHarness(120, 30);
+        var shell = BuildShell();
+        tui.Render();
+
+        ShowAndPump(shell, tui, "queue: added");
+
+        var row = tui.RowOf("queue: added");
+        tui.Line(row - 1).Should().Contain("╭").And.NotContain("queue");
+        tui.Line(row + 1).Should().Contain("╰");
     }
 }


### PR DESCRIPTION
two findings from the full pass before the release.

**`:engine show` printed one of its three lines.** it builds "engine active", "preference" and "supports" separated by newlines. `UiOsdOverlay` was pinned to `Height 3` and took its width from the raw string with the newlines counted in, so the box ran off the right edge and painted only the middle line. it now measures the longest line, clips each line on its own and grows one row per line.

**`:copy` lied on wayland.** the linux path tried xclip then xsel and returned true no matter what happened. on a wayland session xclip exits 0 without owning the selection, so the osd said "copied" and the clipboard kept its old contents. wl-copy is tried first when `WAYLAND_DISPLAY` is set, and a tool that exits non-zero now falls through to the next one instead of counting as success. xclip and wl-copy staying alive to serve the selection is still treated as success, because that is what they normally do.

8 new tests. checked live: all three lines of `:engine show` visible in a correctly sized box, and `:copy title` actually lands in the wayland clipboard now, verified with wl-paste against a sentinel.